### PR TITLE
Ignore changes within the Pickr block

### DIFF
--- a/lib/flatpickr_example_web/controllers/home_live.html.heex
+++ b/lib/flatpickr_example_web/controllers/home_live.html.heex
@@ -1,7 +1,7 @@
 Hi
 
 <.form :let={f} for={@changeset} phx-change="submit" phx-submit="submit">
-  <div phx-hook="Pickr" id="datetime_id">
+  <div phx-update="ignore" phx-hook="Pickr" id="datetime_id">
     <%= text_input f, :datetime, data_input: true, phx_debounce: "blur" %>
     <a style="text-decoration: underline; margin: 0.25em 0; display: block;" data-clear>Clear</a>
   </div>


### PR DESCRIPTION
When using the `altInput` option, flatpickr injects a second input element into the DOM. For this reason you must add `phx-update="ignore"` to the outer element so that LiveView will not overwrite the changes made by flatpickr.

<details>
<summary>altInput=false</summary>
<img width="466" alt="Screen Shot 2023-01-17 at 12 03 51 PM" src="https://user-images.githubusercontent.com/168677/213000651-7b9c753d-490b-434c-9355-74bbfc4c83d2.png">
</details>

<details>
<summary>altInput=true</summary>
<img width="471" alt="Screen Shot 2023-01-17 at 12 04 31 PM" src="https://user-images.githubusercontent.com/168677/213000705-573c5658-2196-4dd4-8db1-dd3f4de09f88.png">

</details>